### PR TITLE
WGU: add 'tbz' to manifest

### DIFF
--- a/unpacker/manifest.json
+++ b/unpacker/manifest.json
@@ -75,7 +75,7 @@
     },
     "tar": {
       "types": ["application/x-tar", "application/x-gtar", "application/x-gtar-compressed"],
-      "extensions": ["gtar", "tar", "tgz", "tbz2", "txz", "tz"]
+      "extensions": ["gtar", "tar", "tgz", "tbz", "tbz2", "txz", "tz"]
     },
     "xz": {
       "types": ["application/x-lzma", "application/x-xz"],


### PR DESCRIPTION
We already support bzip2, and both tbz and tbz2 are valid extensions.